### PR TITLE
Ignore Plex payloads aside from ones with a specific Plex Username

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,15 @@ A Flask app that updates your Discord custom status based on Plex media playback
 
 ## Configuration
 
-1. **Discord Token Setup**
+1. **Environment file config**
    - Create a `.env` file in the project directory
    - Add your Discord user token:
      ```env
      DISCORD_USER_TOKEN=your_discord_user_token_here
+     ```
+   - Add your Plex username:
+     ```env
+     PLEX_USERNAME=your_plex_username_here
      ```
 
 2. **Plex Webhook Setup**
@@ -60,6 +64,7 @@ A Flask app that updates your Discord custom status based on Plex media playback
 - Verify webhook URL in Plex settings
 - Ensure port 5020 is open in firewall/security groups
 - Confirm Discord token is valid
+- Confirm Plex username is entered correctly (may be case sensitive)
 - Check Plex server logs for webhook delivery attempts
 
 ## Example Output

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DISCORD_USER_TOKEN = os.getenv('DISCORD_USER_TOKEN')
+PLEX_USERNAME = os.getenv('PLEX_USERNAME')
 
 log = logging.getLogger('werkzeug')
 log.setLevel(logging.ERROR)
@@ -46,22 +47,25 @@ def plex_webhook():
                 # Parse the JSON payload
                 payload = json.loads(request.form['payload'])
 
-                # Handle play/resume events
-                if payload['event'] in ['media.play', 'media.resume']:
-                    # Check if the media type is a track (music)
-                    if payload['Metadata']['type'] == 'track':
-                        # Extract the song title and artist (grandparentTitle)
-                        title = payload['Metadata']['title']
-                        grandparent_title = payload['Metadata']['grandparentTitle']
+                # Specify user
+                if payload['Account']['title'] == PLEX_USERNAME:
 
-                        # Update Discord status
-                        status_text = f"🎵 Listening to {grandparent_title} - {title}"
-                        update_discord_status(status_text)
+                    # Handle play/resume events
+                    if payload['event'] in ['media.play', 'media.resume']:
+                        # Check if the media type is a track (music)
+                        if payload['Metadata']['type'] == 'track':
+                            # Extract the song title and artist (grandparentTitle)
+                            title = payload['Metadata']['title']
+                            grandparent_title = payload['Metadata']['grandparentTitle']
 
-                # Handle pause/stop events
-                elif payload['event'] in ['media.pause', 'media.stop']:
-                    # Clear Discord status
-                    update_discord_status()  # No argument clears the status
+                            # Update Discord status
+                            status_text = f"🎵 Listening to {grandparent_title} - {title}"
+                            update_discord_status(status_text)
+
+                    # Handle pause/stop events
+                    elif payload['event'] in ['media.pause', 'media.stop']:
+                        # Clear Discord status
+                        update_discord_status()  # No argument clears the status
 
             except Exception as e:
                 print(f"Failed to process payload: {e}")


### PR DESCRIPTION
I updated the README and main to use a new variable that would be entered into the .env file to make it so the script will only watch for play/pause updates from a specific user. In my testing, the original would update when _any_ user would go to play music from my Plex server. Upon testing with my changes and setting the variable to my Plex username, I can see it only updates when I play or pause music.